### PR TITLE
postg-mem 1.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,11 +3,15 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dariogriffo/postg-mem</PackageProjectUrl>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
-    <PackageReleaseNotes>- Initial release</PackageReleaseNotes>
+    <PackageReleaseNotes>- Fleshed out MCP tooling descriptions (#11)
+- Cleaned up README (#10)
+- Added memory relationships (#9)
+- Added schema migrations (#8)
+- Added GitHub Actions support (#7)</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
-#### 1.0.0 May 19th 2025 ####
+#### 1.0.1 May 20th 2025 ####
 
-- Initial release
+- Fleshed out MCP tooling descriptions (#11)
+- Cleaned up README (#10)
+- Added memory relationships (#9)
+- Added schema migrations (#8)
+- Added GitHub Actions support (#7)


### PR DESCRIPTION
#### 1.0.1 May 20th 2025 ####

- Fleshed out MCP tooling descriptions (#11)
- Cleaned up README (#10)
- Added memory relationships (#9)
- Added schema migrations (#8)
- Added GitHub Actions support (#7)